### PR TITLE
APIの戻り値で使われる型をmodule内部に置く提案

### DIFF
--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -3,83 +3,86 @@ interface AtsumaruApiError extends Error {
     readonly code: string
 }
 
-interface StorageItem {
-    key: string
-    value: string
-}
+module AtumaruType{
 
-interface ScoreRecord {
-    rank: number
-    userName: string
-    score: number
-}
+    interface StorageItem {
+        key: string
+        value: string
+    }
 
-interface MyScoreRecord {
-    rank: number
-    score: number
-    isNewRecord: boolean
-}
+    interface ScoreRecord {
+        rank: number
+        userName: string
+        score: number
+    }
 
-interface ScoreboardData {
-    ranking: ScoreRecord[]
-    myRecord: MyScoreRecord | null
-    myBestRecord: ScoreRecord | null
-    boardId: number
-    boardName: string
-}
+    interface MyScoreRecord {
+        rank: number
+        score: number
+        isNewRecord: boolean
+    }
 
-interface GlobalServerVariable {
-    value: number
-    maxValue: number
-    minValue: number
-    name: string
-}
+    interface ScoreboardData {
+        ranking: ScoreRecord[]
+        myRecord: MyScoreRecord | null
+        myBestRecord: ScoreRecord | null
+        boardId: number
+        boardName: string
+    }
 
-interface SharedSaveItems {
-    [userId: number]: string
-}
+    interface GlobalServerVariable {
+        value: number
+        maxValue: number
+        minValue: number
+        name: string
+    }
 
-interface UserInformation {
-    id: number
-    name: string
-    profile: string
-    twitterId: string
-    url: string
-}
+    interface SharedSaveItems {
+        [userId: number]: string
+    }
 
-interface SelfInformation extends UserInformation {
-    isPremium: boolean
-}
+    interface UserInformation {
+        id: number
+        name: string
+        profile: string
+        twitterId: string
+        url: string
+    }
 
-interface UserIdName {
-    id: number
-    name: string
-}
+    interface SelfInformation extends UserInformation {
+        isPremium: boolean
+    }
 
-interface UserSignal {
-    id: number
-    senderId: number
-    senderName: string
-    data: string
-    createdAt: number
-}
+    interface UserIdName {
+        id: number
+        name: string
+    }
 
-interface GlobalSignal {
-    id: number
-    senderId: number
-    senderName: string
-    data: string
-    createdAt: number
-}
+    interface UserSignal {
+        id: number
+        senderId: number
+        senderName: string
+        data: string
+        createdAt: number
+    }
 
-interface CommentItem {
-    command: string
-    comment: string
-}
+    interface GlobalSignal {
+        id: number
+        senderId: number
+        senderName: string
+        data: string
+        createdAt: number
+    }
 
-interface InputInfo {
-    type: string
-    key: string
+    interface CommentItem {
+        command: string
+        comment: string
+    }
+
+    interface InputInfo {
+        type: string
+        key: string
+    }
 }
 
 type NextFunc<T> = ((value: T) => void)
@@ -105,7 +108,7 @@ interface Experimental {
         [key: string]: string
     }
     storage?: {
-        getSharedItems?(userIds: number[], gameId?: number): Promise<SharedSaveItems>
+        getSharedItems?(userIds: number[], gameId?: number): Promise<AtumaruType.SharedSaveItems>
     }
     popups?: {
         openLink?(url: string): Promise<void>
@@ -114,7 +117,7 @@ interface Experimental {
     scoreboards?: {
         setRecord?(boardId: number, score: number): Promise<void>
         display?(boardId: number): Promise<void>
-        getRecords?(boardId: number): Promise<ScoreboardData>
+        getRecords?(boardId: number): Promise<AtumaruType.ScoreboardData>
     }
     screenshot?: {
         displayModal?(): Promise<void>
@@ -122,7 +125,7 @@ interface Experimental {
     }
     globalServerVariable?: {
         triggerCall?(triggerId: number, delta?: number): Promise<void>
-        getGlobalServerVariable?(globalServerVariableId: number): Promise<GlobalServerVariable>
+        getGlobalServerVariable?(globalServerVariableId: number): Promise<AtumaruType.GlobalServerVariable>
     }
     interplayer?: {
         enable?(): Promise<void>
@@ -159,8 +162,8 @@ interface RPGAtsumaruApi {
         pushContextFactor(factor: string): void
         pushMinorContext(): void
         setContext(context: string): void
-        cameOut: Subject<CommentItem[]>
-        posted: Subject<CommentItem>
+        cameOut: Subject<AtumaruType.CommentItem[]>
+        posted: Subject<AtumaruType.CommentItem>
         verbose: boolean
     }
     controllers: {

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -3,7 +3,7 @@ interface AtsumaruApiError extends Error {
     readonly code: string
 }
 
-module AtumaruType{
+declare module "@atsumaru/api-types" {
 
     interface StorageItem {
         key: string

--- a/types/index.d.ts
+++ b/types/index.d.ts
@@ -1,9 +1,9 @@
+
 interface AtsumaruApiError extends Error {
     readonly errorType: string
     readonly code: string
 }
-
-declare module "@atsumaru/api-types" {
+declare module AtsumaruTypes{
 
     interface StorageItem {
         key: string
@@ -84,7 +84,6 @@ declare module "@atsumaru/api-types" {
         key: string
     }
 }
-
 type NextFunc<T> = ((value: T) => void)
 type ErrorFunc = (errorValue: any) => void;
 
@@ -108,7 +107,7 @@ interface Experimental {
         [key: string]: string
     }
     storage?: {
-        getSharedItems?(userIds: number[], gameId?: number): Promise<AtumaruType.SharedSaveItems>
+        getSharedItems?(userIds: number[], gameId?: number): Promise<AtsumaruTypes.SharedSaveItems>
     }
     popups?: {
         openLink?(url: string): Promise<void>
@@ -117,7 +116,7 @@ interface Experimental {
     scoreboards?: {
         setRecord?(boardId: number, score: number): Promise<void>
         display?(boardId: number): Promise<void>
-        getRecords?(boardId: number): Promise<AtumaruType.ScoreboardData>
+        getRecords?(boardId: number): Promise<AtsumaruTypes.ScoreboardData>
     }
     screenshot?: {
         displayModal?(): Promise<void>
@@ -125,20 +124,20 @@ interface Experimental {
     }
     globalServerVariable?: {
         triggerCall?(triggerId: number, delta?: number): Promise<void>
-        getGlobalServerVariable?(globalServerVariableId: number): Promise<AtumaruType.GlobalServerVariable>
+        getGlobalServerVariable?(globalServerVariableId: number): Promise<AtsumaruTypes.GlobalServerVariable>
     }
     interplayer?: {
         enable?(): Promise<void>
     }
     user?: {
-        getUserInformation?(userId: number): Promise<UserInformation>
-        getSelfInformation?(): Promise<SelfInformation>
-        getRecentUsers?(): Promise<UserIdName[]>
+        getUserInformation?(userId: number): Promise<AtsumaruTypes.UserInformation>
+        getSelfInformation?(): Promise<AtsumaruTypes.SelfInformation>
+        getRecentUsers?(): Promise<AtsumaruTypes.UserIdName[]>
     }
     signal?: {
-        getUserSignals?(): Promise<UserSignal[]>
+        getUserSignals?(): Promise<AtsumaruTypes.UserSignal[]>
         sendSignalToUser?(receiverId: number, data: string): Promise<void>
-        getGlobalSignals?(): Promise<GlobalSignal[]>
+        getGlobalSignals?(): Promise<AtsumaruTypes.GlobalSignal[]>
         sendSignalToGlobal?(data: string): Promise<void>
     }
     channel?: {
@@ -149,8 +148,8 @@ interface Experimental {
 interface RPGAtsumaruApi {
     experimental?: Experimental
     storage: {
-        getItems(): Promise<StorageItem[]>
-        setItems(items: StorageItem[]): Promise<void>
+        getItems(): Promise<AtsumaruTypes.StorageItem[]>
+        setItems(items: AtsumaruTypes.StorageItem[]): Promise<void>
         removeItem(key: string): Promise<void>
     }
     popups: {
@@ -162,12 +161,12 @@ interface RPGAtsumaruApi {
         pushContextFactor(factor: string): void
         pushMinorContext(): void
         setContext(context: string): void
-        cameOut: Subject<AtumaruType.CommentItem[]>
-        posted: Subject<AtumaruType.CommentItem>
+        cameOut: Subject<AtsumaruTypes.CommentItem[]>
+        posted: Subject<AtsumaruTypes.CommentItem>
         verbose: boolean
     }
     controllers: {
-        defaultController: Subject<InputInfo>
+        defaultController: Subject<AtsumaruTypes.InputInfo>
     }
     volume: {
         getCurrentValue(): number


### PR DESCRIPTION
入力補完の上での不要な衝突を避ける為に、名前空間の内側に隠しす方が良いのではないでしょうか。
ツクールMV本体はC++やRGSSの文化の影響を受けて、Game_XXになっている。
TypeScriptの文化圏では、修正前の書き方が主流らしいですが、その文化圏にいないので判断しきれない。

一番の理由は、「型にプレフィックスがあるとVScodeで編集する際に探しやすい」ということ。
これについては個人的な理由です。