### PR TITLE
feat(add-global-server-variables): グローバルサーバー変数一括取得などの型を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ RPGアツマールのゲームプレイヤー実行時に参照可能なグロ�
 npm install -D atsumaru/api-types
 ```
 
-
 ### tsconfig.json に依存を書く場合
+
 `tsconfig.json`の`types`を以下に設定します。`types`以外の項目は省略して表記しています。
 
 ```json
@@ -30,7 +30,6 @@ if (window.RPGAtsumaru) {
   ...
 }
 ```
-
 
 ### ファイル中で import を行う場合
 
@@ -61,7 +60,6 @@ import { ScoreRecord } from "@atsumaru/api-types";
 
 const record = ScoreRecord = ...;
 ```
-
 
 ## テストについて
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -14,6 +14,7 @@ declare module "@atsumaru/api-types" {
   interface ScoreRecord {
     rank: number
     userName: string
+    userId: number
     score: number
   }
 
@@ -36,6 +37,22 @@ declare module "@atsumaru/api-types" {
     maxValue: number
     minValue: number
     name: string
+  }
+
+  interface GlobalServerVariableTrigger {
+    triggerId: number
+    triggerType: string
+    memo: string | null
+    argument1: string | null
+    argument2: string | null
+    argument3: string | null
+    argument4: string | null
+    argument5: string | null
+  }
+
+  interface GlobalServerVariableDefinition extends GlobalServerVariable {
+    globalServerVariableId: number
+    triggers: GlobalServerVariableTrigger[]
   }
 
   interface SharedSaveItems {
@@ -80,6 +97,10 @@ declare module "@atsumaru/api-types" {
     comment: string
   }
 
+  interface SceneComment extends CommentItem {
+    context: string
+  }
+
   interface InputInfo {
     type: string
     key: string
@@ -110,6 +131,9 @@ declare module "@atsumaru/api-types" {
     storage?: {
       getSharedItems?(userIds: number[], gameId?: number): Promise<SharedSaveItems>
     }
+    comment?: {
+      getSceneComments?(sceneName: string): Promise<SceneComment[]>
+    }
     popups?: {
       openLink?(url: string): Promise<void>
       displayCreatorInformationModal?(niconicoUserId?: number): Promise<void>
@@ -126,6 +150,7 @@ declare module "@atsumaru/api-types" {
     globalServerVariable?: {
       triggerCall?(triggerId: number, delta?: number): Promise<void>
       getGlobalServerVariable?(globalServerVariableId: number): Promise<GlobalServerVariable>
+      getAllGlobalServerVariables?(): Promise<GlobalServerVariableDefinition[]>
     }
     interplayer?: {
       enable?(): Promise<void>

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@atsumaru/api-types",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {


### PR DESCRIPTION
### 概要

以下のAPIに対応する型を追加します:

- グローバルサーバー変数一括取得
- シーンコメント取得
- スコアボード取得(userIdの追加)