### PR TITLE
chore(install): README.md のインストール手順にブランチ名を追記

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ RPGアツマールのゲームプレイヤー実行時に参照可能なグロ�
 実行にはnpm([https://www.npmjs.com/](https://www.npmjs.com/))が必要です。
 
 ```bash
-npm install -D atsumaru/api-types
+npm install -D atsumaru/api-types#master
 ```
 
 ### tsconfig.json に依存を書く場合


### PR DESCRIPTION
### 概要

- 従来のインストール方法だと常に最新のapi-typesを入手できるとは限らないため、 README.md のインストール手順にブランチ名(master)を追記しました。