### PR TITLE
feat(active-user): オンライン人数APIを追加

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -176,6 +176,7 @@ declare module "@atsumaru/api-types" {
       getUserInformation?(userId: number): Promise<UserInformation>
       getSelfInformation?(): Promise<SelfInformation>
       getRecentUsers?(): Promise<UserIdName[]>
+      getActiveUserCount?(minutes: number): Promise<number>
     }
     signal?: {
       getUserSignals?(): Promise<UserSignal[]>


### PR DESCRIPTION
### 概要

- 今から1～60分前までの間に何人のログインユーザーがゲームをプレイしたのかを取得する、オンライン人数APIを追加します。